### PR TITLE
fix: increase default timeout

### DIFF
--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -156,9 +156,9 @@
     /**
      * The default HTTP timeout for all API calls.
      * @type {Number}
-     * @default 60000
+     * @default 120000
      */
-    this.timeout = 60000;
+    this.timeout = 120000;
 
     /**
      * If set to false an additional timestamp parameter is added to all API GET calls to


### PR DESCRIPTION
This PR increases the default timeout to 120000 because we have very large documents that take extra time to download, causing the request to timeout. According to Docusign logs, the largest request time is ~90000ms.